### PR TITLE
EBMEDS-1450: elastic stack version update

### DIFF
--- a/module/elastic/logstash/module.tf
+++ b/module/elastic/logstash/module.tf
@@ -3,7 +3,7 @@ variable "service-name" {
   default = "logstash"
 }
 variable "elastic-version" {
-  default = "7.4.2"
+  default = "7.6.0"
 }
 variable "ebmeds-log-port" {
   default = 5000

--- a/module/elastic/logstash/pipeline/ebmeds-request.conf
+++ b/module/elastic/logstash/pipeline/ebmeds-request.conf
@@ -12,7 +12,7 @@ filter {
 output {
   elasticsearch {
     hosts => "https://elasticsearch-es-http:9200"
-    index => "ebmeds-requests-%{userId}-%{+YYYY.MM}"
+    index => "ebmeds-requests-%{+YYYY.MM}"
     cacert => "/usr/share/logstash/pipeline/elasticsearch-es-http-certs-public.cer"
     user => "elastic"
     password => "8vswp84kwsmp7wdjm8r9d9ct"

--- a/module/elastic/static/elastic.yaml
+++ b/module/elastic/static/elastic.yaml
@@ -3,7 +3,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 7.4.2
+  version: 7.6.0
   nodeSets:
     - name: elasticsearch
       count: 1
@@ -29,7 +29,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 7.4.2
+  version: 7.6.0
   count: 1
   elasticsearchRef:
     name: elasticsearch
@@ -39,7 +39,7 @@ kind: ApmServer
 metadata:
   name: apm-server
 spec:
-  version: 7.4.2
+  version: 7.6.0
   count: 1
   elasticsearchRef:
     name: elasticsearch


### PR DESCRIPTION
### [EBMEDS-1450](https://jira.duodecim.fi/browse/EBMEDS-1450)

This pull request updates the Elastic to the current latest version (7.6.0) and simplified the `ebmeds-requests-*` Elasticsearch index name. No actionable modifications are required to the EBMEDS to operate with the latest changed Elastic stack.

Before upgrading the existing EBMEDS installation to this current version (7.6.0), make sure that the installed Elastic stack version is **6.8.x**.

More details about upgrading: https://www.elastic.co/guide/en/elastic-stack/7.6/upgrading-elastic-stack.html

**See the related changes:**
- ebmeds-docker: https://github.com/ebmeds/ebmeds-docker/pull/23
- ebmeds-kubernetes: https://github.com/ebmeds/ebmeds-kubernetes/pull/3