### PR TITLE
EBMEDS-1374: ebmeds indices log rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+## How to run locally
 To get it running for testing the following tools are required:
 - [Kube-controller to communication with the Kubernetes cluster](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 - [Minikube to run a single-node Kubernetes cluster in a virtual machine](https://kubernetes.io/docs/tasks/tools/install-minikube/)
@@ -32,3 +33,144 @@ This repository is meant to provide a bare minimum deployment example of EBMEDS 
 
 For further information and instructions on installing EBMEDS, please visit our online documentation at: https://ebmeds.github.io/docs/
 The online documentation site is currently under construction.
+
+## Index Lifecycle Management
+This operation was carried out in Elastic stack version 7.6.0 – current release at the time.
+
+EBMEDS sends request payloads, triggered reminders and logs data into specific Elasticsearch indices. These indices are:
+- ebmeds-request-%{YYYY.MM}
+- ebmeds-reminders-%{YYYY.MM}
+- ebmeds-logs-%{YYYY.MM}
+
+The year and month are dynamically formed to the index name, so for example, `ebmeds-request-2020.03` is one possible name and so on. To control these indices in `testing` and `staging` environments, we need to apply Elasticsearch index lifecycle manager, which set the rotate rules for every index.
+
+In the Elasticsearch and for time series indices, the index lifecycle has four stages, and they are:
+- Hot: the index is actively being updated and queried.
+- Warm: the index is no longer being updated, but is still being queried.
+- Cold: the index is no longer being updated and is seldom queried. The information still needs to be searchable, but it is okay if those queries are slower.
+- Delete: the index is no longer needed and can safely be deleted.
+
+#### Use in testing environment
+For the `testing` environment, we get along just with three phases – hot, warm and delete. All the EBMEDS indices are time series. A new entry to the index enters the `hot` stage. After 30 days it will be moved to the `warm` stage and eventually deleted when the data age reached 90 days. Long story short: data that reside in the index longer than 90 days will be deleted.
+
+The index lifecycle management policy needs to be first created into the Elasticsearch before it can be used in the Logstash else an exception is raised. The `ebmeds-policy` can be added into the Elasticsearch followingly:
+
+```bash
+curl -X PUT "http://localhost:9200/_ilm/policy/ebmeds-index-policy?pretty" -H 'Content-Type: application/json' -d'
+{
+  "policy": {
+    "phases": {
+      "hot": {
+      "min_age": "0ms",
+        "actions": {
+          "rollover": {
+            "max_age": "30d"
+          },
+          "set_priority": {
+            "priority": 100
+          }
+        }
+      },
+      "warm": {
+        "min_age": "0ms",
+        "actions": {
+          "allocate": {
+            "number_of_replicas": 1,
+            "include": {},
+            "exclude": {},
+            "require": {}
+          },
+          "forcemerge": {
+            "max_num_segments": 1
+          },
+          "set_priority": {
+            "priority": 50
+          }
+        }
+      },
+      "delete": {
+        "min_age": "60d",
+        "actions": {
+          "delete": {}
+        }
+      }
+    }
+  }
+}
+'
+```
+
+#### Advice for staging and production environment
+This index lifecycle policy cannot be used in the `staging` and `production` without modification. The snapshot lifecycle must be configured for the `staging` and `production` environments before we can proceed any further. Make sure that the snapshot lifecycle is working correctly before proceeding. 
+
+Also, make sure that everything is tested in `staging` environment and verified that they work correctly before applying index and snapshot lifecycle to the `production`.
+
+Setting up the snapshot repository is required. Here is a simple skeleton snapshot policy of how to take snapshot daily at midnight.
+
+```json
+{
+  "schedule": "0 0 * * * ?",
+  "name": "ebmeds-snapshot-{now/d}",
+  "repository": "<remember to configure repository>",
+  "config": {
+    "indices": ["*"]
+  }
+}
+```
+For more information about snapshot, please consult the links below.  Let say we name this snapshot lifecycle as `ebmeds-snapshot-policy`.
+
+When the snapshot policy is created and running on the indices, we can proceed to set lifecycle policy for the EBMEDS indices. Following is a recommended policy to use with the EBMEDS, but further modification is required depending on the regulations.
+
+```bash
+curl -X PUT "http://localhost:9200/_ilm/policy/ebmeds-index-policy?pretty" -H 'Content-Type: application/json' -d'
+{
+  "policy": {
+    "phases": {
+      "hot": {
+      "min_age": "0ms",
+        "actions": {
+          "rollover": {
+            "max_age": "30d"
+          },
+          "set_priority": {
+            "priority": 100
+          }
+        }
+      },
+      "warm": {
+        "min_age": "0ms",
+        "actions": {
+          "allocate": {
+            "number_of_replicas": 1,
+            "include": {},
+            "exclude": {},
+            "require": {}
+          },
+          "forcemerge": {
+            "max_num_segments": 1
+          },
+          "set_priority": {
+            "priority": 50
+          }
+        }
+      },
+      "delete": {
+        "min_age": "150d",
+        "actions": {
+	  "wait_for_snapshot" : {
+            "policy": "ebmeds-snapshot-policy"
+          }
+          "delete": {}
+        }
+      }
+    }
+  }
+}
+'
+```
+We now set the `delete` stage to wait for the snapshot to be complete before we can proceed with deletion.
+
+#### Further readings:
+- [Manage the index lifecycle](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/index-lifecycle-management.html)
+- [Snapshot and restore](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/snapshot-restore.html)
+- [Manage the snapshot lifecycle](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/snapshot-lifecycle-management.html)

--- a/module/elastic/logstash/pipeline/ebmeds-log.conf
+++ b/module/elastic/logstash/pipeline/ebmeds-log.conf
@@ -15,6 +15,14 @@ output {
     cacert => "/usr/share/logstash/pipeline/elasticsearch-es-http-certs-public.cer"
     user => "elastic"
     password => "8vswp84kwsmp7wdjm8r9d9ct"
+
+    # Set ilm_enabled value to be true
+    # when ebmeds-index-policy exists in Elasticsearch.
+    ilm_enabled => false
+
+    ilm_rollover_alias => "ebmeds-logs"
+    ilm_pattern => "{now{YYYY.MM}}-00001"
+    ilm_policy => "ebmeds-index-policy"
   }
 }
 

--- a/module/elastic/logstash/pipeline/ebmeds-reminder.conf
+++ b/module/elastic/logstash/pipeline/ebmeds-reminder.conf
@@ -28,5 +28,13 @@ output {
     cacert => "/usr/share/logstash/pipeline/elasticsearch-es-http-certs-public.cer"
     user => "elastic"
     password => "8vswp84kwsmp7wdjm8r9d9ct"
+
+    # Set ilm_enabled value to be true
+    # when ebmeds-index-policy exists in Elasticsearch.
+    ilm_enabled => false
+
+    ilm_rollover_alias => "ebmeds-reminders"
+    ilm_pattern => "{now{YYYY.MM}}-00001"
+    ilm_policy => "ebmeds-index-policy"
   }
 }

--- a/module/elastic/logstash/pipeline/ebmeds-request.conf
+++ b/module/elastic/logstash/pipeline/ebmeds-request.conf
@@ -16,5 +16,13 @@ output {
     cacert => "/usr/share/logstash/pipeline/elasticsearch-es-http-certs-public.cer"
     user => "elastic"
     password => "8vswp84kwsmp7wdjm8r9d9ct"
+
+    # Set ilm_enabled value to be true
+    # when ebmeds-index-policy exists in Elasticsearch.
+    ilm_enabled => false
+
+    ilm_rollover_alias => "ebmeds-requests"
+    ilm_pattern => "{now{YYYY.MM}}-00001"
+    ilm_policy => "ebmeds-index-policy"
   }
 }


### PR DESCRIPTION
### [EBMEDS-1374](https://jira.duodecim.fi/browse/EBMEDS-1374)

This pull request adds an index lifecycle management to the EBMEDS indices.

### Index Lifecycle Management
This operation was carried out in Elastic stack version 7.6.0 – current release at the time.

EBMEDS sends request payloads, triggered reminders and logs data into specific Elasticsearch indices. These indices are:
- ebmeds-request-%{YYYY.MM}
- ebmeds-reminders-%{YYYY.MM}
- ebmeds-logs-%{YYYY.MM}

The year and month are dynamically formed to the index name, so for example, `ebmeds-request-2020.03` is one possible name and so on. To control these indices in `testing` and `staging` environments, we need to apply Elasticsearch index lifecycle manager, which set the rotate rules for every index.

In the Elasticsearch and for time series indices, the index lifecycle has four stages, and they are:
- Hot: the index is actively being updated and queried.
- Warm: the index is no longer being updated, but is still being queried.
- Cold: the index is no longer being updated and is seldom queried. The information still needs to be searchable, but it is okay if those queries are slower.
- Delete: the index is no longer needed and can safely be deleted.

#### Use in testing environment
For the `testing` environment, we get along just with three phases – hot, warm and delete. All the EBMEDS indices are time series. A new entry to the index enters the `hot` stage. After 30 days it will be moved to the `warm` stage and eventually deleted when the data age reached 90 days. Long story short: data that reside in the index longer than 90 days will be deleted.

The index lifecycle management policy needs to be first created into the Elasticsearch before it can be used in the Logstash else an exception is raised. The `ebmeds-policy` can be added into the Elasticsearch followingly:

```bash
curl -X PUT "http://localhost:9200/_ilm/policy/ebmeds-index-policy?pretty" -H 'Content-Type: application/json' -d'
{
  "policy": {
    "phases": {
      "hot": {
      "min_age": "0ms",
        "actions": {
          "rollover": {
            "max_age": "30d"
          },
          "set_priority": {
            "priority": 100
          }
        }
      },
      "warm": {
        "min_age": "0ms",
        "actions": {
          "allocate": {
            "number_of_replicas": 1,
            "include": {},
            "exclude": {},
            "require": {}
          },
          "forcemerge": {
            "max_num_segments": 1
          },
          "set_priority": {
            "priority": 50
          }
        }
      },
      "delete": {
        "min_age": "60d",
        "actions": {
          "delete": {}
        }
      }
    }
  }
}
'
```

#### Advice for staging and production environment
This index lifecycle policy cannot be used in the `staging` and `production` without modification. The snapshot lifecycle must be configured for the `staging` and `production` environments before we can proceed any further. Make sure that the snapshot lifecycle is working correctly before proceeding. 

Also, make sure that everything is tested in `staging` environment and verified that they work correctly before applying index and snapshot lifecycle to the `production`.

Setting up the snapshot repository is required. Here is a simple skeleton snapshot policy of how to take snapshot daily at midnight.

```json
{
  "schedule": "0 0 * * * ?",
  "name": "ebmeds-snapshot-{now/d}",
  "repository": "<remember to configure repository>",
  "config": {
    "indices": ["*"]
  }
}
```
For more information about snapshot, please consult the links below.  Let say we name this snapshot lifecycle as `ebmeds-snapshot-policy`.

When the snapshot policy is created and running on the indices, we can proceed to set lifecycle policy for the EBMEDS indices. Following is a recommended policy to use with the EBMEDS, but further modification is required depending on the regulations.

```bash
curl -X PUT "http://localhost:9200/_ilm/policy/ebmeds-index-policy?pretty" -H 'Content-Type: application/json' -d'
{
  "policy": {
    "phases": {
      "hot": {
      "min_age": "0ms",
        "actions": {
          "rollover": {
            "max_age": "30d"
          },
          "set_priority": {
            "priority": 100
          }
        }
      },
      "warm": {
        "min_age": "0ms",
        "actions": {
          "allocate": {
            "number_of_replicas": 1,
            "include": {},
            "exclude": {},
            "require": {}
          },
          "forcemerge": {
            "max_num_segments": 1
          },
          "set_priority": {
            "priority": 50
          }
        }
      },
      "delete": {
        "min_age": "150d",
        "actions": {
	  "wait_for_snapshot" : {
            "policy": "ebmeds-snapshot-policy"
          }
          "delete": {}
        }
      }
    }
  }
}
'
```
We now set the `delete` stage to wait for the snapshot to be complete before we can proceed with deletion.

#### Further readings and information:
- [Manage the index lifecycle](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/index-lifecycle-management.html)
- [Snapshot and restore](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/snapshot-restore.html)
- [Manage the snapshot lifecycle](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/snapshot-lifecycle-management.html)


**See related changes:**
- ebmeds-docker: https://github.com/ebmeds/ebmeds-docker/pull/24