### PR TITLE
EBMEDS-1992: Missing request and reminder log data

### DIFF
--- a/module/elastic/logstash/pipeline/ebmeds-reminder.conf
+++ b/module/elastic/logstash/pipeline/ebmeds-reminder.conf
@@ -25,6 +25,8 @@ output {
   elasticsearch {
     hosts => "https://elasticsearch-es-http:9200"
     index => "ebmeds-reminders-%{+YYYY.MM}"
+    document_id => "%{requestId}:%{logId}"
+
     cacert => "/usr/share/logstash/pipeline/elasticsearch-es-http-certs-public.cer"
     user => "elastic"
     password => "8vswp84kwsmp7wdjm8r9d9ct"

--- a/module/elastic/logstash/pipeline/ebmeds-request.conf
+++ b/module/elastic/logstash/pipeline/ebmeds-request.conf
@@ -13,6 +13,8 @@ output {
   elasticsearch {
     hosts => "https://elasticsearch-es-http:9200"
     index => "ebmeds-requests-%{+YYYY.MM}"
+    document_id => "%{requestId}"
+
     cacert => "/usr/share/logstash/pipeline/elasticsearch-es-http-certs-public.cer"
     user => "elastic"
     password => "8vswp84kwsmp7wdjm8r9d9ct"


### PR DESCRIPTION
### EBMEDS-1992

Overwrite the request and reminder log document id to abolish Elasticsearch duplicate entries.

### See related changes:
- API-Gateway: https://github.com/ebmeds/api-gateway/pull/186
- Engine: https://github.com/ebmeds/engine/pull/391
- EBMEDS-Docker: https://github.com/ebmeds/ebmeds-docker/pull/25
- EBMEDS-Kubernetes: https://github.com/ebmeds/ebmeds-kubernetes/pull/5